### PR TITLE
Add worker for rabbit hole ingestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ofetch": "^1.3.4",
     "officeparser": "^4.0.8",
     "pdf-parse": "^1.1.1",
+    "piscina": "^4.4.0",
     "pkg-types": "^1.0.3",
     "qs": "^6.12.0",
     "scule": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ dependencies:
   pdf-parse:
     specifier: ^1.1.1
     version: 1.1.1
+  piscina:
+    specifier: ^4.4.0
+    version: 4.4.0
   pkg-types:
     specifier: ^1.0.3
     version: 1.0.3
@@ -5750,6 +5753,22 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
+  /nice-napi@1.0.2:
+    resolution: {integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==}
+    os: ['!win32']
+    requiresBuild: true
+    dependencies:
+      node-addon-api: 3.2.1
+      node-gyp-build: 4.8.0
+    dev: false
+    optional: true
+
+  /node-addon-api@3.2.1:
+    resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -5782,6 +5801,13 @@ packages:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
     dev: false
+
+  /node-gyp-build@4.8.0:
+    resolution: {integrity: sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
@@ -6288,6 +6314,12 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
     dev: true
+
+  /piscina@4.4.0:
+    resolution: {integrity: sha512-+AQduEJefrOApE4bV7KRmp3N2JnnyErlVqq4P/jmko4FPz9Z877BCccl/iB3FdrWSUkvbGV9Kan/KllJgat3Vg==}
+    optionalDependencies:
+      nice-napi: 1.0.2
+    dev: false
 
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,46 @@
+import { log } from '@logger'
+import { rabbitHole } from '@rh'
+import type { StrayCat } from '@lg/stray-cat.ts'
+
+type WorkerData = {
+	stray: StrayCat
+	source?: string
+	chunkSize?: number
+	chunkOverlap?: number
+} & ({
+	kind: 'file' | 'memory'
+	content: File
+} | {
+	kind: 'text' | 'url'
+	content: string
+})
+
+export default async (data: WorkerData) => {
+	const { stray, chunkSize, chunkOverlap, content, kind, source } = {
+		chunkSize: 256,
+		chunkOverlap: 64,
+		source: 'unknown',
+		...data,
+	}
+	try {
+		switch (kind) {
+			case 'file':
+				await rabbitHole.ingestFile(stray, content, chunkSize, chunkOverlap)
+				break
+			case 'memory':
+				await rabbitHole.ingestMemory(content)
+				break
+			case 'text':
+				await rabbitHole.ingestContent(stray, content, source)
+				break
+			case 'url':
+				await rabbitHole.ingestPathOrURL(stray, content, chunkSize, chunkOverlap)
+				break
+			default:
+				throw new Error('Unknown kind of content to ingest.')
+		}
+	}
+	catch (error) {
+		log.error('Error while ingesting:', error)
+	}
+}


### PR DESCRIPTION
Fix top-level `await` because it is not supported as the worker gets transpiled to `.cjs`.
So CheshireCat, RabbitHole and MadHatter classes are causing issues with this new feature.