### PR TITLE
Improve plugin importing using Blobs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path'
-import { readdirSync, statSync, unlinkSync } from 'node:fs'
 import nodemon from 'nodemon'
 import { log } from './src/logger.ts'
 import { parsedEnv } from './src/utils.ts'
@@ -11,7 +9,7 @@ nodemon({
 	watch: ['src/**', '.env'],
 	exec: 'bun',
 	script: 'src/main.ts',
-	ignoreRoot: watch ? ['**/settings.json', '**/tmp_*.ts', 'src/plugins/**', 'src/assets/**'] : ['**/**'],
+	ignoreRoot: watch ? ['**/settings.json', 'src/plugins/**', 'src/assets/**'] : ['**/**'],
 	env: {
 		NODE_ENV: watch ? 'development' : 'production',
 		NODE_NO_WARNINGS: verbose ? '0' : '1',
@@ -24,19 +22,9 @@ nodemon.once('start', () => {
 	log.info('Restarting the Cat...')
 }).on('quit', () => {
 	log.info('Stopping the Cat...')
-	deleteTempFiles('./src')
 	process.exit()
 })
 
 process.on('SIGINT', () => {
 	nodemon.emit('quit')
 })
-
-function deleteTempFiles(path: string) {
-	readdirSync(path).forEach((file) => {
-		const filePath = join(path, file)
-		const isDirectory = statSync(filePath).isDirectory()
-		if (isDirectory) deleteTempFiles(filePath)
-		else if (file.startsWith('tmp_') && file.endsWith('.ts')) unlinkSync(filePath)
-	})
-}

--- a/src/looking_glass/stray-cat.ts
+++ b/src/looking_glass/stray-cat.ts
@@ -1,4 +1,5 @@
-import callsites from 'callsites'
+// import { resolveObjectURL } from 'node:buffer'
+// import callsites from 'callsites'
 import type { BaseCallbackHandler } from '@langchain/core/callbacks/base'
 import { Document } from '@langchain/core/documents'
 import { madHatter } from '@mh'
@@ -59,17 +60,21 @@ export class StrayCat {
 	}
 
 	/**
-	 * Retrieves information about the plugin where is being executed.
+	 * Retrieves information about a plugin based on its ID.
 	 * @returns An object containing the plugin's active status, manifest, and settings.
+	 *
 	 * Returns undefined if the plugin is not found.
 	 */
-	getPluginInfo() {
-		const paths = callsites().map(site => site.getFileName())
-		const folder = paths.find(path => path?.includes('src/plugins/'))
-		if (!folder) return undefined
-		const match = folder.match(/src\/plugins\/(.+?)\/tmp/)
-		if (!match || !match[1]) return undefined
-		const id = match[1]
+	async getPluginInfo(id: string) {
+		// TODO: Wait for Bun to implement the `resolveObjectURL` method.
+		/* const paths = callsites().map(site => site.getFileName())
+		const tmp = paths.find(path => path?.includes('blob:'))
+		if (!tmp) return undefined
+		const blob = resolveObjectURL(tmp)
+		if (!blob) return undefined
+		const text = await blob.text()
+		const id = text.match(/^\/\/ ID:\s*(\S+)/)?.[1]
+		if (!id) return undefined */
 		const plugin = madHatter.getPlugin(id)
 		if (!plugin) return undefined
 		const { active, manifest, settings } = plugin

--- a/src/mad_hatter/mad-hatter.ts
+++ b/src/mad_hatter/mad-hatter.ts
@@ -135,7 +135,9 @@ export class MadHatter {
 	async removePlugin(id: string) {
 		const plugin = this.plugins.get(id)
 		if (plugin) {
+			log.debug(`Removing plugin: ${id}`)
 			plugin.triggerEvent('removed')
+			plugin.fileUrls.forEach(u => URL.revokeObjectURL(u))
 			const requirementsPath = join(plugin.path, 'requirements.txt')
 			if (existsDir(requirementsPath)) {
 				const requirements = await Bun.file(requirementsPath).text()
@@ -219,7 +221,7 @@ export class MadHatter {
 export const madHatter = await MadHatter.getInstance()
 
 chokidar.watch('src/plugins', {
-	ignored: ['**/settings.json', '**/tmp_*.ts'],
+	ignored: ['**/settings.json'],
 	ignoreInitial: true,
 	persistent: true,
 }).on('all', async (event, path) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,11 +141,10 @@ export async function compareStrings(input: string, prediction: string, criteria
 }
 
 /**
- * **Waiting for a Bun internal method to be implemented.**
- *
  * Checks if a directory exists.
  * @param path The path to the directory to check.
  */
+// TODO: Wait for a Bun internal method to be implemented
 export const existsDir = (path: string) => !!Array.from(new Bun.Glob(path).scanSync({ onlyFiles: false }))[0]
 
 /**


### PR DESCRIPTION
With this PR I improved the import of plugins' methods using Blobs and URLs by transpiling the TS code.
Pros:
- Faster reading
- No more temporary files in the codebase while starting the Cat, causing some files to stay in disk if you stop the process too early.
- Cleaner code

Cons:
- Blob URLs need to stay in memory to be able to use `getPluginInfo` from MadHatter, but the `resolveObjectURL` is not implemented yet.

Linked to the con, we have two choices:
- Add an `id` param in the `getPluginInfo` but the plugins will be able to get other plugins infos (which may be what we want?)
- Patch the `resolveObjectURL` with our own version until Bun releases its own (it will require us to write C/Zig code).